### PR TITLE
convert rdf list argument values to arrays

### DIFF
--- a/arguments.js
+++ b/arguments.js
@@ -7,7 +7,6 @@ function isList (node) {
 
 async function parseArguments (args, options) {
   // is it a list?
-  // if (args.out(ns.rdf.first).terms.length === 1) {
   if (isList(args)) {
     return Promise.all([...args.list()].map(arg => parseArgument(arg, options)))
   }

--- a/arguments.js
+++ b/arguments.js
@@ -1,9 +1,14 @@
 const cf = require('clownface')
 const ns = require('./namespaces')
 
+function isList (node) {
+  return node.out(ns.rdf.first).terms.length === 1
+}
+
 async function parseArguments (args, options) {
   // is it a list?
-  if (args.out(ns.rdf.first).terms.length === 1) {
+  // if (args.out(ns.rdf.first).terms.length === 1) {
+  if (isList(args)) {
     return Promise.all([...args.list()].map(arg => parseArgument(arg, options)))
   }
 
@@ -31,6 +36,11 @@ async function parseArgument (arg, { context, variables, basePath, loaderRegistr
 
   if (arg.term.termType === 'Literal') {
     return arg.value
+  }
+
+  if (isList(arg)) {
+    // if it's a list, iterate over each item and run the parse argument logic on it
+    return Promise.all([...arg.list()].map(item => parseArgument(item, { context, variables, basePath, loaderRegistry })))
   }
 
   return arg

--- a/test/arguments-named-list.ttl
+++ b/test/arguments-named-list.ttl
@@ -1,0 +1,7 @@
+@prefix code: <https://code.described.at/> .
+
+<http://example.com/> code:arguments [
+  code:name "foo"; code:value "bar"
+], [
+  code:name "a"; code:value ("b" "c")
+].

--- a/test/arguments.test.js
+++ b/test/arguments.test.js
@@ -118,6 +118,24 @@ describe('arguments loader', () => {
       }])
     })
 
+    test('should support array values', async () => {
+      // given
+      const options = {
+        loaderRegistry
+      }
+      const dataset = await loadDataset('./arguments-named-list.ttl')
+      const args = cf(dataset).node(rootNode).out(ns.code.arguments)
+
+      // when
+      const result = await loader(args, dataset, options)
+
+      // then
+      expect(result).toEqual([{
+        'foo': 'bar',
+        'a': ['b', 'c']
+      }])
+    })
+
     test('should forward options to loaderRegistry', async () => {
       // given
       const options = {


### PR DESCRIPTION
The argument loader contains already some logic to convert simple types (literals) to plain strings. This PR also adds support for rdf:List. List will be converted to arrays.