### PR TITLE
replaced term dataset arguments with named argument interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
 before_install:
   - npm install -g codecov
 script:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to be executed in their programs.
 
 ## Installation
 
-Currently must be installed from git
+The code loader and the loader registry can be installed with the following lines:  
 
 ```
 npm i --save rdf-loader-code
@@ -53,10 +53,10 @@ const rdf = require('rdf-ext')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:example:node')
+const term = rdf.namedNode('urn:example:node')
 const implementedBy = rdf.namedNode('https://code.described.at/implementedBy')
 
-const createReadStream = registry.load(cf(dataset).node(parentNode).out(implementedBy))
+const createReadStream = registry.load(cf({ term, dataset }).out(implementedBy))
 ```
 
 ### JS code loaded from source file
@@ -79,11 +79,11 @@ const rdf = require('rdf-ext')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:example:node')
+const term = rdf.namedNode('urn:example:node')
 const implementedBy = rdf.namedNode('https://code.described.at/implementedBy')
 
 const myCode = registry.load(
-  cf(dataset).node(parentNode).out(implementedBy),
+  cf({ term, dataset }).out(implementedBy),
   {
     basePath: process.cwd() // required to resolve relative paths
   })
@@ -111,10 +111,10 @@ const rdf = require('rdf-ext')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:example:node')
+const term = rdf.namedNode('urn:example:node')
 const implementedBy = rdf.namedNode('https://code.described.at/implementedBy')
 
-const filterFunc = registry.load(cf(dataset).node(parentNode).out(implementedBy))
+const filterFunc = registry.load(cf({ term, dataset }).out(implementedBy))
 ```
 
 ### JS template string literal
@@ -137,14 +137,14 @@ const rdf = require('rdf-ext')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:example:node')
+const term = rdf.namedNode('urn:example:node')
 const implementedBy = rdf.namedNode('https://code.described.at/implementedBy')
 
 const variables = new Map()
 variables.set('name', 'World')
 
 const helloString = registry.load(
-  cf(dataset).node(parentNode).out(implementedBy),
+  cf({ term, dataset }).out(implementedBy),
   {
     variables
   })
@@ -162,7 +162,7 @@ The actual argument values will be recursively loaded using the loader registry 
 Note that the arguments loader cannot be registered with the registry because selection is based on an
 `rdf:type` which is not available when defining the triples (check the exampels below). For that reason
 the loader must always be called directly and it is the caller's responsibility to select the correct
-RDF node. Hence, the `code:arguments` is just used as convention and not really mandatory.
+RDF node which contains the `code:arguments` property.
 
 #### Positional parameters
 
@@ -189,11 +189,10 @@ const loadArguments = require('rdf-loader-code/arguments')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:call:string#startsWith')
-const argumentsProp = rdf.namedNode('https://code.described.at/arguments')
+const term = rdf.namedNode('urn:call:string#startsWith')
 
 const argumentsArray = loadArguments(
-  cf(dataset).node(parentNode).out(argumentsProp), 
+  cf({ term, dataset }), 
   {
     loaderRegistry: registry
   })
@@ -236,11 +235,10 @@ const loadArguments = require('rdf-loader-code/arguments')
 const registry = require('./registry')
 const dataset = require('./dataset')
 
-const parentNode = rdf.namedNode('urn:call:string#startsWith')
-const argumentsProp = rdf.namedNode('https://code.described.at/arguments')
+const term = rdf.namedNode('urn:call:string#startsWith')
 
 const argumentsObject = loadArguments(
-  cf(dataset).node(parentNode).out(argumentsProp),
+  cf({ term, dataset }),
   {
     loaderRegistry: registry
   })

--- a/arguments.js
+++ b/arguments.js
@@ -2,7 +2,7 @@ const cf = require('clownface')
 const ns = require('./namespaces')
 
 function isList (node) {
-  return node.out(ns.rdf.first).terms.length === 1
+  return node.out(ns.rdf('first')).terms.length === 1
 }
 
 async function parseArguments (args, options) {
@@ -13,12 +13,12 @@ async function parseArguments (args, options) {
 
   // or an object?
   const argNodes = args.toArray()
-  const promises = argNodes.map((argNode) => parseArgument(argNode.out(ns.code.value), options))
+  const promises = argNodes.map((argNode) => parseArgument(argNode.out(ns.code('value')), options))
   const values = await Promise.all(promises)
 
   // merge all key value pairs into an object
   const argObject = argNodes.reduce((acc, argNode, idx) => {
-    acc[argNode.out(ns.code.name).value] = values[idx]
+    acc[argNode.out(ns.code('name')).value] = values[idx]
 
     return acc
   }, {})
@@ -45,6 +45,8 @@ async function parseArgument (arg, { context, variables, basePath, loaderRegistr
   return arg
 }
 
-module.exports = (node, dataset, options) => {
-  return parseArguments(cf(dataset).node(node), options)
+async function loader ({ term, dataset }, { property = ns.code('arguments'), ...options } = {}) {
+  return parseArguments(cf({ term, dataset }).out(property), options)
 }
+
+module.exports = loader

--- a/ecmaScript.js
+++ b/ecmaScript.js
@@ -1,38 +1,36 @@
 const cf = require('clownface')
 const iriRequire = require('./iriRequire')
-const { code } = require('./namespaces')
+const ns = require('./namespaces')
 
-function parseLiteral (node, { context }) {
-  if (node.datatype.equals(code('EcmaScript'))) {
-    return (function () { return eval(`(${node.value})`) }).call(context) // eslint-disable-line no-eval,no-extra-parens
+function parseLiteral ({ term }, { context } = {}) {
+  if (term.datatype.equals(ns.code('EcmaScript'))) {
+    return (function () { return eval(`(${term.value})`) }).call(context) // eslint-disable-line no-eval,no-extra-parens
   }
 
-  throw new Error(`Cannot load ecmaScript code from node ${node}`)
+  throw new Error(`Cannot load ecmaScript code from term ${term.value}`)
 }
 
-function parseNamedNode (node, dataset, { basePath }) {
-  const def = cf(dataset)
-  const cfNode = def.node(node)
-  const link = cfNode.out(code('link'))
+function parseNamedNode ({ term, dataset }, { basePath } = {}) {
+  const link = cf({ term, dataset }).out(ns.code('link'))
 
   if (link.term && link.term.termType === 'NamedNode') {
     return iriRequire(link.value, basePath)
   }
 
-  throw new Error(`Cannot load ecmaScript code from node ${node}`)
+  throw new Error(`Cannot load ecmaScript code from term ${term.value}`)
 }
 
-function loader (node, dataset, options) {
-  if (node && node.termType === 'Literal') {
-    return parseLiteral(node, options)
+function loader ({ term, dataset }, options = {}) {
+  if (term && term.termType === 'Literal') {
+    return parseLiteral({ term, dataset }, options)
   }
 
-  return parseNamedNode(node, dataset, options)
+  return parseNamedNode({ term, dataset }, options)
 }
 
 loader.register = registry => {
-  registry.registerNodeLoader(code('EcmaScript'), loader)
-  registry.registerLiteralLoader(code('EcmaScript'), loader)
+  registry.registerNodeLoader(ns.code('EcmaScript'), loader)
+  registry.registerLiteralLoader(ns.code('EcmaScript'), loader)
 }
 
 module.exports = loader

--- a/ecmaScriptLiteral.js
+++ b/ecmaScriptLiteral.js
@@ -1,16 +1,16 @@
 const evalTemplateLiteral = require('./evalTemplateLiteral')
-const { code } = require('./namespaces')
+const ns = require('./namespaces')
 
-function loader (node, dataset, { context, variables }) {
-  if (!(node.termType !== 'Literal' || !node.datatype.equals(code('EcmaScriptTemplateLiteral')))) {
-    return evalTemplateLiteral(node.value, { context, variables })
+function loader ({ term }, { context, variables } = {}) {
+  if (!(term.termType !== 'Literal' || !term.datatype.equals(ns.code('EcmaScriptTemplateLiteral')))) {
+    return evalTemplateLiteral(term.value, { context, variables })
   }
 
-  throw new Error(`Cannot load ES6 literal from node ${node}`)
+  throw new Error(`Cannot load ES6 literal from term ${term.value}`)
 }
 
 loader.register = registry => {
-  registry.registerLiteralLoader(code('EcmaScriptTemplateLiteral'), loader)
+  registry.registerLiteralLoader(ns.code('EcmaScriptTemplateLiteral'), loader)
 }
 
 module.exports = loader

--- a/iriRequire.js
+++ b/iriRequire.js
@@ -5,7 +5,7 @@ const isUrl = new RegExp('^[a-z]*://')
 
 function parseIri (iri) {
   if (isUrl.test(iri)) {
-    return url.parse(iri)
+    return url.parse(iri) // eslint-disable-line node/no-deprecated-api
   }
 
   const colonIndex = iri.indexOf(':')

--- a/namespaces.js
+++ b/namespaces.js
@@ -1,5 +1,11 @@
 const namespace = require('@rdfjs/namespace')
 
+/*
+  Namespaces should be used with function call in the library like: ns.code('link')
+  That avoids problems for platforms without Proxy support.
+  In the test code, the namespaces can be used with the property like: ns.code.link
+*/
+
 module.exports = {
   code: namespace('https://code.described.at/'),
   rdf: namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-loader-code",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JavaScript native types loader for the Code ontology",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,22 +19,16 @@
   },
   "homepage": "https://github.com/zazuko/rdf-loader-code",
   "dependencies": {
-    "@rdfjs/namespace": "^1.0.0",
-    "clownface": "^0.10.0"
+    "@rdfjs/namespace": "^1.1.0",
+    "clownface": "^0.12.0"
   },
   "devDependencies": {
+    "@rdfjs/data-model": "^1.1.2",
+    "@rdfjs/dataset": "^1.0.1",
     "@rdfjs/parser-n3": "^1.1.2",
-    "@types/sinon": "^7.0.11",
-    "jest": "^24.1.0",
-    "rdf-ext": "^1.2.2",
+    "jest": "^24.9.0",
+    "rdf-dataset-ext": "^1.0.0",
     "sinon": "^7.3.2",
-    "standard": "^12.0.1",
-    "expect": "^24.7.1"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "*.js"
-    ]
+    "standard": "^14.3.1"
   }
 }

--- a/test/ecmaScript.test.js
+++ b/test/ecmaScript.test.js
@@ -66,22 +66,22 @@ describe('ecmaScript loader', () => {
   describe('loading from node:', () => {
     test('should return top export', () => {
       // given
-      // <operation> code:link <node:rdf-ext#namedNode>
+      // <operation> code:link <node:@rdfjs/data-model#namedNode>
       const node = def.node(example('operation'))
-      node.addOut(ns.code.link, rdf.namedNode('node:rdf-ext#namedNode'))
+      node.addOut(ns.code.link, rdf.namedNode('node:@rdfjs/data-model#namedNode'))
 
       // when
       const func = loader({ term: node.term, dataset: node.dataset })
 
       // then
-      expect(func.name).toBe('namedNode')
+      expect(typeof func).toBe('function')
     })
 
     test('should return correct function if using dot notation', () => {
       // given
-      // <operation> code:link <node:rdf-ext#namedNode.name>
+      // <operation> code:link <node:@rdfjs/data-model#namedNode.name>
       const node = def.node(example('operation'))
-      node.addOut(ns.code.link, rdf.namedNode('node:rdf-ext#namedNode.name'))
+      node.addOut(ns.code.link, rdf.namedNode('node:@rdfjs/data-model#namedNode.name'))
 
       // when
       const str = loader({ term: node.term, dataset: node.dataset })

--- a/test/ecmaScriptLiteral.test.js
+++ b/test/ecmaScriptLiteral.test.js
@@ -1,25 +1,18 @@
-/* global describe, test, beforeEach */
-const rdf = require('rdf-ext')
-const expect = require('expect')
+/* global describe, expect, test */
+
+const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const loader = require('../ecmaScriptLiteral')
-const { code } = require('../namespaces')
+const ns = require('../namespaces')
 
 describe('ecmaScriptTemplate loader', () => {
-  let dataset
-
-  beforeEach(() => {
-    dataset = rdf.dataset()
-  })
-
   test('should return string filled in with variables', () => {
     // given
     // eslint-disable-next-line no-template-curly-in-string
-    const node = rdf.literal('Hello ${hello}', code('EcmaScriptTemplateLiteral'))
-    const variables = new Map()
-    variables.set('hello', 'world')
+    const term = rdf.literal('Hello ${hello}', ns.code.EcmaScriptTemplateLiteral)
+    const variables = new Map([['hello', 'world']])
 
     // when
-    const string = loader(node, dataset, { context: {}, variables })
+    const string = loader({ term, dataset: rdf.dataset() }, { variables })
 
     // then
     expect(string).toBe('Hello world')
@@ -27,12 +20,12 @@ describe('ecmaScriptTemplate loader', () => {
 
   test('should throw if node is not literal', () => {
     // given
-    const node = rdf.namedNode('not:literal:node')
+    const term = rdf.namedNode('not:literal:node')
 
     // then
     expect(() => {
       // when
-      loader(node)
+      loader({ term, dataset: rdf.dataset() })
     }).toThrow()
   })
 })


### PR DESCRIPTION
Changed the interface of the loader to the named argument interface with `term` and `dataset` to align to the latest changes in the repository. This required changes in the argument loader. Arguments were loaded from different terms in the old code if multiple named arguments were used. Now the entry point is one level higher and the loader checks for the `code:argument` property.