### PR TITLE
feat: map native type of literals

### DIFF
--- a/.changeset/yellow-points-shout.md
+++ b/.changeset/yellow-points-shout.md
@@ -1,0 +1,7 @@
+---
+"rdf-loader-code": major
+---
+
+Preserve the type of literal by loading them as native JS objects.
+Any literal supported by [rdf-literal](https://npm.im/rdf-literal) will be converted to appropriate type.
+An error will be thrown in the value does not correspond with the lexical representation of the given datatype.

--- a/arguments.js
+++ b/arguments.js
@@ -1,4 +1,5 @@
 import clownface from 'clownface'
+import { fromRdf } from 'rdf-literal'
 import * as ns from './namespaces.js'
 
 function isList(node) {
@@ -34,7 +35,7 @@ async function parseArgument(arg, { context, variables, basePath, loaderRegistry
   }
 
   if (arg.term.termType === 'Literal') {
-    return arg.value
+    return fromRdf(arg.term, true)
   }
 
   if (isList(arg)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "rdf-loader-code",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rdf-loader-code",
-      "version": "0.3.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/namespace": "^2.0.0",
-        "clownface": "^2.0.0"
+        "clownface": "^2.0.0",
+        "rdf-literal": "^1.3.1"
       },
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
@@ -797,7 +798,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
       "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -892,8 +892,7 @@
     "node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6362,7 +6361,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
       "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -6375,6 +6373,15 @@
       "dependencies": {
         "rdf-canonize": "^3.0.0",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/rdf-literal": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.1.tgz",
+      "integrity": "sha512-+o/PGOfJchyay9Rjrvi/oveRJACnt2WFO3LhEvtPlsRD1tFmwVUCMU+s33FtQprMo+z1ohFrv/yfEQ6Eym4KgQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
       }
     },
     "node_modules/rdf-utils-fs": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/zazuko/rdf-loader-code",
   "dependencies": {
     "@rdfjs/namespace": "^2.0.0",
-    "clownface": "^2.0.0"
+    "clownface": "^2.0.0",
+    "rdf-literal": "^1.3.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",

--- a/test/arguments-list.ttl
+++ b/test/arguments-list.ttl
@@ -1,5 +1,6 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix code: <https://code.described.at/> .
 
 <http://example.com/> code:arguments (
-  "a" 5
+  "a" 5 true 5.6 "2000-11-20"^^xsd:date
 ) .

--- a/test/arguments.test.js
+++ b/test/arguments.test.js
@@ -11,12 +11,12 @@ describe('arguments loader', () => {
   const term = rdf.namedNode('http://example.com/')
 
   describe('loading from rdf:List', () => {
-    it('should fall back to verbatim literal value', async () => {
+    it('should fall back to native literal value', async () => {
       const dataset = await loadDataset('./arguments-list.ttl')
 
       const result = await loader({ term, dataset }, { loaderRegistry: dummyLoaderRegistry })
 
-      deepStrictEqual(result, ['a', '5'])
+      deepStrictEqual(result, ['a', 5, true, 5.6, new Date(Date.UTC(2000, 10, 20))])
     })
 
     it('should handle boolean false, but not undefined values from loaders', async () => {
@@ -28,7 +28,7 @@ describe('arguments loader', () => {
 
       const result = await loader({ term, dataset }, { loaderRegistry })
 
-      deepStrictEqual(result, ['a', ''])
+      deepStrictEqual(result, ['a', '', true, 5.6, new Date(Date.UTC(2000, 10, 20))])
     })
 
     it('should use loaders to load values', async () => {
@@ -39,7 +39,7 @@ describe('arguments loader', () => {
 
       const result = await loader({ term, dataset }, { loaderRegistry })
 
-      deepStrictEqual(result, ['A', '5'])
+      deepStrictEqual(result, ['A', '5', 'TRUE', '5.6', '2000-11-20'])
     })
 
     it('should forward options to loaderRegistry', async () => {


### PR DESCRIPTION
I think this deserves a major version (in barnard too), because it may accidentally break code which assumed that loaded values are always string