### PR TITLE
fix: windows compatibility to import modules using filename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on: 
+  - push
+  - pull_request
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/lib/iriResolve.ts
+++ b/lib/iriResolve.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'url'
 import { resolve } from 'path'
 
 type IRI = Pick<URL, 'protocol' | 'pathname' | 'hash'>
@@ -13,7 +14,7 @@ const resolvers = new Map<string, Resolver>([
     }
 
     if (base) {
-      return resolve(base, url.pathname)
+      return pathToFileURL(resolve(base, url.pathname)).toString()
     }
 
     return url.pathname


### PR DESCRIPTION
this enables cube validation to run on windows

see also https://github.com/zazuko/cube-link/pull/128