### PR TITLE
feat: simple key/value pairs

### DIFF
--- a/.changeset/shaggy-pants-hammer.md
+++ b/.changeset/shaggy-pants-hammer.md
@@ -1,0 +1,5 @@
+---
+"rdf-loader-code": minor
+---
+
+Add simpler syntax for creating key/value pair arguments (closes #37, closes #38)

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -200,13 +200,13 @@ loading of an argument map. Such arguments are declared as name/value pairs.
 
 ```turtle
 @prefix code: <https://code.described.at/>.
+@prefix arg: <https://code.described.at/argument#>.
 
 <urn:call:string#startsWith> 
-  code:arguments [
-    code:name "first"; code:value "foo"
-  ], [
-    code:name "second"; code:value "bar"
-  ] .
+    code:arguments ([
+      arg:first "foo" ;
+      arg:second "bar" ;
+    ]) .
 ```
 
 Executing the code below against the above triples will return an object containing the values
@@ -220,20 +220,32 @@ Executing the code below against the above triples will return an object contain
 ]
 ```
 
-To make this method consistent with the positional flavor, the object will actually be wrapped
-in an array as presented above. 
+#### Mixed arguments
+
+Both methods can be sed together to represent any kind of function signature.
+
+For example, to call a function as below
 
 ```js
-import rdf from '@zazuko/env'
-import loadArguments from 'rdf-loader-code/arguments.js'
-import registry from './registry.js'
-import dataset from './dataset.js'
+myFunction('foo', 42, { bar: {  baz: 'baz' } })
+```
 
-const term = rdf.namedNode('urn:call:string#startsWith')
+You would declare the argument list as follows:
 
-const argumentsObject = loadArguments(
-  rdf.clownface({ term, dataset }),
-  {
-    loaderRegistry: registry
-  })
+```turtle
+@prefix code: <https://code.described.at/> .
+@prefix arg: <https://code.described.at/argument#> .
+
+<urn:call:myFunction>
+  code:arguments
+    (
+      "foo"
+      42
+      [
+        arg:bar
+          [
+            arg:baz "baz"
+          ]
+      ]
+    ) .
 ```

--- a/arguments.ts
+++ b/arguments.ts
@@ -56,7 +56,7 @@ async function parseArgument(arg: AnyPointer, { context, variables, basePath, lo
       return []
     })
 
-  const argMap = Object.fromEntries(await Promise.all(loadingNamedArgs))
+  const argMap = Object.fromEntries((await Promise.all(loadingNamedArgs)).filter(([key]) => !!key))
 
   if (Object.keys(argMap).length > 0) {
     return argMap

--- a/test/arguments-shorthand.ttl
+++ b/test/arguments-shorthand.ttl
@@ -1,0 +1,20 @@
+@prefix arg: <https://code.described.at/argument#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix code: <https://code.described.at/> .
+
+<http://example.com/single> code:arguments
+        (
+            [
+                arg:foo "foo" ;
+                arg:bar true ;
+                arg:baz 10 ;
+            ]
+        ) .
+
+
+<http://example.com/nested> code:arguments
+        (
+            [
+                arg:foo [ arg:bar [ arg:baz "buzz" ] ] ;
+            ]
+        ) .

--- a/test/arguments.test.js
+++ b/test/arguments.test.js
@@ -129,4 +129,34 @@ describe('arguments loader', () => {
       }
     })
   })
+
+  describe('shorthand syntax', () => {
+    it('load key-value pairs from a single blank node', async () => {
+      const term = rdf.namedNode('http://example.com/single')
+      const dataset = await loadDataset('./arguments-shorthand.ttl')
+
+      const result = await loader({ term, dataset }, { loaderRegistry: dummyLoaderRegistry })
+
+      deepStrictEqual(result, [{
+        foo: 'foo',
+        bar: true,
+        baz: 10,
+      }])
+    })
+
+    it('load deep key-value pairs', async () => {
+      const term = rdf.namedNode('http://example.com/nested')
+      const dataset = await loadDataset('./arguments-shorthand.ttl')
+
+      const result = await loader({ term, dataset }, { loaderRegistry: dummyLoaderRegistry })
+
+      deepStrictEqual(result, [{
+        foo: {
+          bar: {
+            baz: 'buzz',
+          },
+        },
+      }])
+    })
+  })
 })


### PR DESCRIPTION
This will greatly simplify the verbose way for writing names arguments

Turned out that a single change already implements both #37 and #38